### PR TITLE
Pile : des adresses et des valeurs : a gèrer pour les branch

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+Ant-Version: Apache Ant 1.9.9
+Created-By: 1.8.0_151-8u151-b12-1~deb9u1-b12 (Oracle Corporation)
+Main-Class: fr.umlv.littlethinker.Main
+

--- a/fr/umlv/littlethinker/Processor.java
+++ b/fr/umlv/littlethinker/Processor.java
@@ -734,7 +734,12 @@ public class Processor extends JPanel{
 	    int value;
 	    if (nbToken == 2) {
 	        if (b.getAsBoolean()) {
-                value = Integer.parseInt(cmd[1]);
+	        	//TODO homogénéiser le décodage des adresses... getAddress ne marche pas bien !!
+	        	if (cmd[1].charAt(0) == '#') {
+	        		value = registers.getR(Integer.parseInt(cmd[1].substring(1)));
+	        	} else {
+	        		value = Integer.parseInt(cmd[1]);
+	        	}
                 controls.setI(value, slider.getValue());
                 return true;
 	        }
@@ -752,7 +757,7 @@ public class Processor extends JPanel{
 	 */
 	private int getAdress(String str) {
 		int res;
-		String tmp = str.substring(1);
+		String tmp = str.substring(1); //pourquoi ???
 		if (tmp.charAt(0) == '#') {
 			res = registers.getR(Integer.parseInt(tmp.substring(1)));
 		}


### PR DESCRIPTION
C'est pas encore très bien. Mais pour faire un appel de fonction, on empile l'adresse de retour. Et il faut donc pouvoir fournir aux fonctions de branchement ces valeurs, qu'on trouvera dans un registre...
exemple : on met une fonction en 40 qui incrémente le registre, et on lui passe un arg
ps3   //l'adresse de retour sera 3, puisque je passe un arg et j'appelle la fonciton
ps 10  // mon argument
brn 40  // appel de fonction
st #0 $20 // je suis revenu, j'ai la valeur en #0 je le stocke quelque part
...
..
(en 40)
pp  #0 // je récupére l'argument
inc #0 // je fais mon boulot de fonction
pp #4 // préparation du retour, je choisis #4 pour connaitre l'adresse de reprise
brn #4 //rentrons maison...

 
